### PR TITLE
add a BitVec wrapper

### DIFF
--- a/rkyv_wrappers/Cargo.toml
+++ b/rkyv_wrappers/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2018"
 
 [dependencies]
 rkyv = "0.7"
+bitvec = { version = "1.0.1", optional = true }
+bytecheck = { version = "~0.6.8", optional = true, default-features = false }
 
 [features]
 default = []
-validation = ["rkyv/validation"]
+validation = ["rkyv/validation", "bytecheck"]

--- a/rkyv_wrappers/src/as_hashmap.rs
+++ b/rkyv_wrappers/src/as_hashmap.rs
@@ -1,8 +1,8 @@
 //! A wrapper that converts a `Vec` to an `ArchivedHashMap` at serialization time.
 
 use rkyv::{
-    ser::{ScratchSpace, Serializer},
     collections::hash_map::{ArchivedHashMap, HashMapResolver},
+    ser::{ScratchSpace, Serializer},
     with::{ArchiveWith, DeserializeWith, SerializeWith},
     Archive, Deserialize, Fallible, Serialize,
 };
@@ -70,10 +70,7 @@ impl<
     fn serialize_with(field: &Vec<(K, V)>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
         // The user must guarantee that the vector contains unique keys
         unsafe {
-            ArchivedHashMap::serialize_from_iter(
-                field.iter().map(|(x, y)| (x, y)),
-                serializer,
-            )
+            ArchivedHashMap::serialize_from_iter(field.iter().map(|(x, y)| (x, y)), serializer)
         }
     }
 }

--- a/rkyv_wrappers/src/bitvec.rs
+++ b/rkyv_wrappers/src/bitvec.rs
@@ -50,7 +50,11 @@ pub struct BitVecWrapper;
 // We also have to store the bit length.
 // This is because when calling `as_raw_slice` we will get unwanted bits if the `BitVec` bit length is not a multiple of the bit size of T.
 #[cfg_attr(feature = "validation", derive(bytecheck::CheckBytes))]
-pub struct ArchivedBitVec<T: BitStore + Archive, O: BitOrder> {
+pub struct ArchivedBitVec<T = Archived<usize>, O = Lsb0>
+where
+    T: BitStore + Archive,
+    O: BitOrder,
+{
     inner: ArchivedVec<Archived<T>>,
     bit_len: Archived<usize>,
     _or: PhantomData<O>,

--- a/rkyv_wrappers/src/bitvec.rs
+++ b/rkyv_wrappers/src/bitvec.rs
@@ -1,0 +1,130 @@
+//! A wrapper that allows to archive a `BitVec` using internally an `ArchivedVec`.
+
+use std::{marker::PhantomData, ops::Deref};
+
+use bitvec::prelude::*;
+use rkyv::{
+    out_field,
+    ser::{ScratchSpace, Serializer},
+    vec::{ArchivedVec, VecResolver},
+    with::{ArchiveWith, DeserializeWith, SerializeWith},
+    Archive, Archived, Deserialize, Fallible, Serialize,
+};
+
+/// A wrapper that allows to archive a `BitVec<T, O>` using internally an `ArchivedVec`.
+/// All the `BitSlice<T, O>` methods are available on the archived type thanks to the `Deref` trait implementation.
+///
+/// Example:
+///
+/// ```rust
+/// use rkyv_wrappers::bitvec::BitVecWrapper;
+/// use bitvec::prelude::*;
+/// use rkyv::{
+///     archived_root,
+///     ser::{serializers::AllocSerializer, Serializer},
+///     Archive, Deserialize, Infallible, Serialize,
+/// };
+///
+/// #[derive(Archive, Serialize, Deserialize, PartialEq, Debug)]
+/// struct StructWithBitVec {
+///     #[with(BitVecWrapper)]
+///     pub bitvec: BitVec,
+/// }
+///
+/// let mut serializer = AllocSerializer::<4096>::default();
+/// let original = StructWithBitVec {
+///     bitvec: bitvec![1, 0, 1, 1, 1],
+/// };
+/// serializer.serialize_value(&original).unwrap();
+/// let buffer = serializer.into_serializer().into_inner();
+///
+/// let output = unsafe { archived_root::<StructWithBitVec>(&buffer) };
+/// assert_eq!(&original.bitvec, output.bitvec.as_slice());
+///
+/// let deserialized: StructWithBitVec = output.deserialize(&mut Infallible).unwrap();
+/// assert_eq!(deserialized, original);
+/// ```
+pub struct BitVecWrapper;
+
+/// An archived `BitVec`.
+// We also have to store the bit length.
+// This is because when calling `as_raw_slice` we will get unwanted bits if the `BitVec` bit length is not a multiple of the bit size of T.
+#[cfg_attr(feature = "validation", derive(bytecheck::CheckBytes))]
+pub struct ArchivedBitVec<T: BitStore + Archive, O: BitOrder> {
+    inner: ArchivedVec<Archived<T>>,
+    bit_len: Archived<usize>,
+    _or: PhantomData<O>,
+}
+
+impl<T: BitStore + Archive, O: BitOrder> ArchivedBitVec<T, O>
+where
+    Archived<T>: BitStore,
+{
+    /// Gets the elements of the archived `BitVec` as a `BitSlice`.
+    pub fn as_slice(&self) -> &BitSlice<Archived<T>, O> {
+        self.deref()
+    }
+}
+
+impl<T: BitStore + Archive, O: BitOrder> Deref for ArchivedBitVec<T, O>
+where
+    Archived<T>: BitStore,
+{
+    type Target = BitSlice<Archived<T>, O>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.view_bits::<O>()[..self.bit_len as usize]
+    }
+}
+
+impl<T: BitStore + Archive, O: BitOrder> ArchiveWith<BitVec<T, O>> for BitVecWrapper {
+    type Archived = ArchivedBitVec<T, O>;
+    type Resolver = VecResolver;
+
+    unsafe fn resolve_with(
+        field: &BitVec<T, O>,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        let (fp, fo) = out_field!(out.inner);
+        ArchivedVec::resolve_from_slice(field.as_raw_slice(), pos + fp, resolver, fo);
+        let (fp, fo) = out_field!(out.bit_len);
+        usize::resolve(&field.len(), pos + fp, (), fo);
+    }
+}
+
+impl<
+        T: BitStore + Archive + Serialize<S>,
+        O: BitOrder,
+        S: Fallible + ?Sized + ScratchSpace + Serializer,
+    > SerializeWith<BitVec<T, O>, S> for BitVecWrapper
+{
+    fn serialize_with(
+        field: &BitVec<T, O>,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, <S as Fallible>::Error> {
+        let resolver = ArchivedVec::serialize_from_slice(field.as_raw_slice(), serializer)?;
+        usize::serialize(&field.len(), serializer)?;
+
+        Ok(resolver)
+    }
+}
+
+impl<T: BitStore + Archive, O: BitOrder, D: Fallible + ?Sized>
+    DeserializeWith<ArchivedBitVec<T, O>, BitVec<T, O>, D> for BitVecWrapper
+where
+    Archived<T>: Deserialize<T, D>,
+{
+    fn deserialize_with(
+        field: &ArchivedBitVec<T, O>,
+        deserializer: &mut D,
+    ) -> Result<BitVec<T, O>, <D as Fallible>::Error> {
+        let vec = ArchivedVec::deserialize(&field.inner, deserializer)?;
+        let bit_len = Archived::<usize>::deserialize(&field.bit_len, deserializer)?;
+
+        let mut bitvec = BitVec::<T, O>::from_vec(vec);
+        bitvec.truncate(bit_len);
+        Ok(bitvec)
+    }
+}

--- a/rkyv_wrappers/src/custom_phantom.rs
+++ b/rkyv_wrappers/src/custom_phantom.rs
@@ -2,14 +2,14 @@
 
 use rkyv::{
     with::{ArchiveWith, DeserializeWith, SerializeWith},
-    Fallible
+    Fallible,
 };
 use std::marker::PhantomData;
 
 /// A wrapper that allows for changing the generic type of a PhantomData<T>.
-/// 
+///
 /// Example:
-/// 
+///
 /// ```rust
 /// use std::marker::PhantomData;
 /// use rkyv::{
@@ -29,28 +29,40 @@ use std::marker::PhantomData;
 /// let value = StructWithPhantom::<Vec<i32>>::default();
 /// let bytes = rkyv::to_bytes::<_, 1024>(&value).unwrap();
 /// let archived: &StructWithPhantom<ArchivedVec<i32>> = unsafe { rkyv::archived_root::<StructWithPhantom<Vec<i32>>>(&bytes) };
-/// 
+///
 /// let deserialized: StructWithPhantom<Vec<i32>> = archived.deserialize(&mut Infallible).unwrap();
 /// assert_eq!(deserialized, value);
 /// ```
-pub struct CustomPhantom<NT: ?Sized> { _data: PhantomData<*const NT> }
+pub struct CustomPhantom<NT: ?Sized> {
+    _data: PhantomData<*const NT>,
+}
 
 impl<OT: ?Sized, NT: ?Sized> ArchiveWith<PhantomData<OT>> for CustomPhantom<NT> {
     type Archived = PhantomData<NT>;
     type Resolver = ();
 
     #[inline]
-    unsafe fn resolve_with(_: &PhantomData<OT>, _: usize, _: Self::Resolver, _: *mut Self::Archived) {}
+    unsafe fn resolve_with(
+        _: &PhantomData<OT>,
+        _: usize,
+        _: Self::Resolver,
+        _: *mut Self::Archived,
+    ) {
+    }
 }
 
-impl<OT: ?Sized, NT: ?Sized, S: Fallible + ?Sized> SerializeWith<PhantomData<OT>, S> for CustomPhantom<NT> {
+impl<OT: ?Sized, NT: ?Sized, S: Fallible + ?Sized> SerializeWith<PhantomData<OT>, S>
+    for CustomPhantom<NT>
+{
     #[inline]
     fn serialize_with(_: &PhantomData<OT>, _: &mut S) -> Result<Self::Resolver, S::Error> {
         Ok(())
     }
 }
 
-impl<OT: ?Sized, NT: ?Sized, D: Fallible + ?Sized> DeserializeWith<PhantomData<NT>, PhantomData<OT>, D> for CustomPhantom<NT> {
+impl<OT: ?Sized, NT: ?Sized, D: Fallible + ?Sized>
+    DeserializeWith<PhantomData<NT>, PhantomData<OT>, D> for CustomPhantom<NT>
+{
     #[inline]
     fn deserialize_with(_: &PhantomData<NT>, _: &mut D) -> Result<PhantomData<OT>, D::Error> {
         Ok(PhantomData)

--- a/rkyv_wrappers/src/lib.rs
+++ b/rkyv_wrappers/src/lib.rs
@@ -7,5 +7,8 @@
 pub mod as_hashmap;
 pub mod custom_phantom;
 
+#[cfg(feature = "bitvec")]
+pub mod bitvec;
+
 #[cfg(test)]
 pub mod tests;


### PR DESCRIPTION
Hi!

I promised a while ago that I would polish my BitVec wrapper and post it so here we go.

> bitvec provides a foundational API for bitfields in Rust. It specializes standard-library data structures (slices, arrays, and vectors of bool) to use one-bit-per-bool storage, similar to [std::bitset<N>](https://en.cppreference.com/w/cpp/utility/bitset) and [std::vector<bool>](https://en.cppreference.com/w/cpp/container/vector_bool) in C++.

This adds a `BitVecWrapper` that can be used with the `#[with(BitVecWrapper)]` attribute as shown in the doc example in src/bitvec.rs. It is available under the `bitvec` feature flag.

I'm not 100% of the correctness of this code, but if it works well enough `Archive` could be directly implemented on `BitVec` in the main `rkyv` crate.