### PR TITLE
WIP migration to 0.8

### DIFF
--- a/rkyv_wrappers/Cargo.toml
+++ b/rkyv_wrappers/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rkyv = "0.7"
+rkyv = "0.8"
+bytecheck = "0.8"
 
 [features]
 default = []
-validation = ["rkyv/validation"]
+validation = ["rkyv/bytecheck"]

--- a/rkyv_wrappers/src/custom_phantom.rs
+++ b/rkyv_wrappers/src/custom_phantom.rs
@@ -11,33 +11,36 @@ use std::marker::PhantomData;
 ///
 /// Example:
 ///
-/// ```rust,ignore
+/// ```rust
 /// use std::marker::PhantomData;
 /// use rkyv::{
-///     bytecheck, Portable, Archive, Serialize, Deserialize, rancor::Infallible, vec::ArchivedVec, Archived, with::With,
+///     deserialize, bytecheck, Portable, Archive, Deserialize, Serialize, rancor::Infallible, vec::ArchivedVec, Archived, with::With,
+///     rancor::Error,
 /// };
 /// use rkyv_wrappers::custom_phantom::CustomPhantom;
 /// use rkyv::with::ArchiveWith;
 /// #[repr(C)]
-/// #[derive(Portable, Archive, Serialize, Deserialize, bytecheck::CheckBytes, Debug, PartialEq, Eq, Default)]
-/// #[rkyv(as = StructWithPhantom<T::Archived>, archive_bounds(
-/// 	T: Archive,
-/// 	With<PhantomData<T>, CustomPhantom<Archived<T>>>: Archive<Archived = PhantomData<Archived<T>>>
-/// ), deserialize_bounds(
-/// 	T: Archive,
-/// ))]
+/// #[derive(Archive, Serialize, Deserialize, bytecheck::CheckBytes, Debug, PartialEq, Eq, Default)]
+/// #[rkyv(compare(PartialEq), derive(Debug))]
+/// // This should not be necessary, but somehow rustc needs a push in the right direction.
+/// #[rkyv(archive_bounds(CustomPhantom<T>: ArchiveWith<PhantomData<T>, Archived = PhantomData<T>>))]
 /// struct StructWithPhantom<T> {
-/// 	//pub num: i32,
-///     #[rkyv(with = CustomPhantom<T::Archived>)]
+/// 	pub num: i32,
+///     #[rkyv(with = CustomPhantom<T>)]
 ///     pub phantom: PhantomData<T>,
 /// }
-/// let value = StructWithPhantom::<Vec<rkyv::rend::i32_le>>::default();
+/// let value = StructWithPhantom::<Vec<i32>>::default();
 /// let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
-/// let archived = rkyv::access::<StructWithPhantom<ArchivedVec<rkyv::rend::i32_le>>, rkyv::rancor::Error>(&bytes)
-///   .unwrap();
+/// let archived = rkyv::access::<ArchivedStructWithPhantom<Vec<i32>>, Error>(&bytes[..]).unwrap();
+///  assert_eq!(archived, &value);
 ///
-/// // let deserialized: StructWithPhantom<Vec<rkyv::rend::i32_le>> = archived.deserialize().unwrap();
-/// assert_eq!(archived, &value);
+/// let new_value = StructWithPhantom::<Vec<i32>> {
+///     num: 42,
+///     phantom: PhantomData,
+/// };
+///
+/// let deserialized = deserialize::<StructWithPhantom<Vec<i32>>, Error>(archived).unwrap();
+/// assert_eq!(&deserialized, &value);
 /// ```
 pub struct CustomPhantom<NT: ?Sized> {
     _data: PhantomData<*const NT>,

--- a/rkyv_wrappers/src/custom_phantom.rs
+++ b/rkyv_wrappers/src/custom_phantom.rs
@@ -1,56 +1,68 @@
 //! A wrapper that converts a `Vec` to an `ArchivedHashMap` at serialization time.
 
 use rkyv::{
+    rancor::Fallible,
     with::{ArchiveWith, DeserializeWith, SerializeWith},
-    Fallible
+    Place,
 };
 use std::marker::PhantomData;
 
 /// A wrapper that allows for changing the generic type of a PhantomData<T>.
-/// 
+///
 /// Example:
-/// 
-/// ```rust
+///
+/// ```rust,ignore
 /// use std::marker::PhantomData;
 /// use rkyv::{
-///     Archive, Serialize, Deserialize, Infallible, vec::ArchivedVec, Archived, with::With,
+///     bytecheck, Portable, Archive, Serialize, Deserialize, rancor::Infallible, vec::ArchivedVec, Archived, with::With,
 /// };
 /// use rkyv_wrappers::custom_phantom::CustomPhantom;
-/// #[derive(Archive, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
-/// #[archive(as = "StructWithPhantom<T::Archived>", bound(archive = "
+/// use rkyv::with::ArchiveWith;
+/// #[repr(C)]
+/// #[derive(Portable, Archive, Serialize, Deserialize, bytecheck::CheckBytes, Debug, PartialEq, Eq, Default)]
+/// #[rkyv(as = StructWithPhantom<T::Archived>, archive_bounds(
 /// 	T: Archive,
 /// 	With<PhantomData<T>, CustomPhantom<Archived<T>>>: Archive<Archived = PhantomData<Archived<T>>>
-/// "))]
+/// ), deserialize_bounds(
+/// 	T: Archive,
+/// ))]
 /// struct StructWithPhantom<T> {
-/// 	pub num: i32,
-///     #[with(CustomPhantom<T::Archived>)]
+/// 	//pub num: i32,
+///     #[rkyv(with = CustomPhantom<T::Archived>)]
 ///     pub phantom: PhantomData<T>,
 /// }
-/// let value = StructWithPhantom::<Vec<i32>>::default();
-/// let bytes = rkyv::to_bytes::<_, 1024>(&value).unwrap();
-/// let archived: &StructWithPhantom<ArchivedVec<i32>> = unsafe { rkyv::archived_root::<StructWithPhantom<Vec<i32>>>(&bytes) };
-/// 
-/// let deserialized: StructWithPhantom<Vec<i32>> = archived.deserialize(&mut Infallible).unwrap();
-/// assert_eq!(deserialized, value);
+/// let value = StructWithPhantom::<Vec<rkyv::rend::i32_le>>::default();
+/// let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
+/// let archived = rkyv::access::<StructWithPhantom<ArchivedVec<rkyv::rend::i32_le>>, rkyv::rancor::Error>(&bytes)
+///   .unwrap();
+///
+/// // let deserialized: StructWithPhantom<Vec<rkyv::rend::i32_le>> = archived.deserialize().unwrap();
+/// assert_eq!(archived, &value);
 /// ```
-pub struct CustomPhantom<NT: ?Sized> { _data: PhantomData<*const NT> }
+pub struct CustomPhantom<NT: ?Sized> {
+    _data: PhantomData<*const NT>,
+}
 
 impl<OT: ?Sized, NT: ?Sized> ArchiveWith<PhantomData<OT>> for CustomPhantom<NT> {
     type Archived = PhantomData<NT>;
     type Resolver = ();
 
     #[inline]
-    unsafe fn resolve_with(_: &PhantomData<OT>, _: usize, _: Self::Resolver, _: *mut Self::Archived) {}
+    fn resolve_with(_: &PhantomData<OT>, _: Self::Resolver, _: Place<Self::Archived>) {}
 }
 
-impl<OT: ?Sized, NT: ?Sized, S: Fallible + ?Sized> SerializeWith<PhantomData<OT>, S> for CustomPhantom<NT> {
+impl<OT: ?Sized, NT: ?Sized, S: Fallible + ?Sized> SerializeWith<PhantomData<OT>, S>
+    for CustomPhantom<NT>
+{
     #[inline]
     fn serialize_with(_: &PhantomData<OT>, _: &mut S) -> Result<Self::Resolver, S::Error> {
         Ok(())
     }
 }
 
-impl<OT: ?Sized, NT: ?Sized, D: Fallible + ?Sized> DeserializeWith<PhantomData<NT>, PhantomData<OT>, D> for CustomPhantom<NT> {
+impl<OT: ?Sized, NT: ?Sized, D: Fallible + ?Sized>
+    DeserializeWith<PhantomData<NT>, PhantomData<OT>, D> for CustomPhantom<NT>
+{
     #[inline]
     fn deserialize_with(_: &PhantomData<NT>, _: &mut D) -> Result<PhantomData<OT>, D::Error> {
         Ok(PhantomData)

--- a/rkyv_wrappers/src/lib.rs
+++ b/rkyv_wrappers/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::missing_crate_level_docs)]
 
-pub mod as_hashmap;
+//pub mod as_hashmap;
 pub mod custom_phantom;
 
-#[cfg(test)]
-pub mod tests;
+// #[cfg(test)]
+// pub mod tests;

--- a/rkyv_wrappers/src/tests.rs
+++ b/rkyv_wrappers/src/tests.rs
@@ -1,29 +1,30 @@
-pub mod as_hashmap {
-    #[test]
-    fn struct_with_hashmap() {
-        use rkyv::{
-            archived_root,
-            ser::{serializers::AllocSerializer, Serializer},
-            Deserialize, Infallible,
-        };
+// pub mod as_hashmap {
+// #[test]
+// fn struct_with_hashmap() {
+//     use rkyv::{
+//         archived_root,
+//         rancor::Infallible,
+//         ser::{serializers::AllocSerializer, Serializer},
+//         Deserialize,
+//     };
 
-        #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug, PartialEq, Eq)]
-        struct StructWithHashMap {
-            #[with(crate::as_hashmap::AsHashMap)]
-            pub hash_map: Vec<(u32, String)>,
-        }
+//     #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug, PartialEq, Eq)]
+//     struct StructWithHashMap {
+//         #[rkyv(with = crate::as_hashmap::AsHashMap)]
+//         pub hash_map: Vec<(u32, String)>,
+//     }
 
-        let mut serializer = AllocSerializer::<4096>::default();
-        let original = StructWithHashMap {
-            hash_map: vec![(1, String::from("a")), (2, String::from("b"))],
-        };
-        serializer.serialize_value(&original).unwrap();
-        let buffer = serializer.into_serializer().into_inner();
+//     let mut serializer = AllocSerializer::<4096>::default();
+//     let original = StructWithHashMap {
+//         hash_map: vec![(1, String::from("a")), (2, String::from("b"))],
+//     };
+//     serializer.serialize_value(&original).unwrap();
+//     let buffer = serializer.into_serializer().into_inner();
 
-        let output = unsafe { archived_root::<StructWithHashMap>(&buffer) };
-        assert_eq!(output.hash_map.get(&1).unwrap(), &"a");
+//     let output = unsafe { archived_root::<StructWithHashMap>(&buffer) };
+//     assert_eq!(output.hash_map.get(&1).unwrap(), &"a");
 
-        let deserialized: StructWithHashMap = output.deserialize(&mut Infallible).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
+//     let deserialized: StructWithHashMap = output.deserialize(&mut Infallible).unwrap();
+//     assert_eq!(deserialized, original);
+// }
+// }


### PR DESCRIPTION
This is actually me trying to learn rkyv 0.8 ; it's not working yet.

## Current status

- `hash_map` is commented, let's focus on `CustomPhantom` first.

Fixing example code for `CustomPhantom` was not trivial, because:
- We have to use this non obvious `#[rkyv(archive_bounds(CustomPhantom<T>: ArchiveWith<PhantomData<T>, Archived = PhantomData<T>>))]` to make help rustc understand.
- I had to remove `as = StructWithPhantom<T::Archived>`, because it requires Self to be portable, and that `i32` is not.
  - This is a bit unfortunate, I'd like to have generic field to be able to use `as`, but that might make the code more complex, maybe in another PR after discussion/validation?

### Resolved

I keep these in the desription, even though it's been resolved.

#### Failing test when still using `as = ...`:
<details><summary>Details</summary>
<p>

```rs
   Doc-tests rkyv_wrappers

running 1 test
test rkyv_wrappers/src/custom_phantom.rs - custom_phantom::CustomPhantom (line 14) ... FAILED

failures:

---- rkyv_wrappers/src/custom_phantom.rs - custom_phantom::CustomPhantom (line 14) stdout ----
error[E0308]: mismatched types
   --> rkyv_wrappers/src/custom_phantom.rs:23:20
    |
12  | #[derive(Portable, Archive, Serialize, Deserialize, bytecheck::CheckBytes, Debug, PartialEq, Eq, Default)]
    |                    ^^^^^^^
    |                    |
    |                    expected `Place<<... as ArchiveWith<...>>::Archived>`, found `Place<PhantomData<T>>`
    |                    arguments to this function are incorrect
    |
    = note: expected struct `Place<<CustomPhantom<T> as ArchiveWith<PhantomData<T>>>::Archived>`
               found struct `Place<PhantomData<T>>`
    = help: consider constraining the associated type `<CustomPhantom<T> as ArchiveWith<PhantomData<T>>>::Archived` to `PhantomData<T>` or calling a method that returns `<CustomPhantom<T> as ArchiveWith<PhantomData<T>>>::Archived`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
note: associated function defined here
   --> /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rkyv-0.8.10/src/with.rs:114:8
    |
114 |     fn resolve_with(
    |        ^^^^^^^^^^^^
    = note: this error originates in the derive macro `Archive` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
   --> rkyv_wrappers/src/custom_phantom.rs:23:40
    |
12  | #[derive(Portable, Archive, Serialize, Deserialize, bytecheck::CheckBytes, Debug, PartialEq, Eq, Default)]
    |                                        ^^^^^^^^^^^
    |                                        |
    |                                        expected `&<CustomPhantom<T> as ArchiveWith<...>>::Archived`, found `&PhantomData<T>`
    |                                        arguments to this function are incorrect
    |
    = note: expected reference `&<CustomPhantom<T> as ArchiveWith<PhantomData<T>>>::Archived`
               found reference `&PhantomData<T>`
    = help: consider constraining the associated type `<CustomPhantom<T> as ArchiveWith<PhantomData<T>>>::Archived` to `PhantomData<T>` or calling a method that returns `<CustomPhantom<T> as ArchiveWith<PhantomData<T>>>::Archived`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
note: associated function defined here
   --> /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rkyv-0.8.10/src/with.rs:139:8
    |
139 |     fn deserialize_with(field: &F, deserializer: &mut D)
    |        ^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0308`.
Couldn't compile the test.

failures:
    rkyv_wrappers/src/custom_phantom.rs - custom_phantom::CustomPhantom (line 14)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

</p>
</details> 